### PR TITLE
Updated to make resource_pool and targethost optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ mkmf.log
 .chef
 local/
 .vscode/
+.chef/

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ knife[:vcenter_disable_ssl_verify] = true # if you want to disable SSL checking
 or alternatively you can supply them on the command-line:
 
 ```bash
-knife vcenter _command_ --vcenter-username myuser --vcanter-password mypassword
+knife vcenter _command_ --vcenter-username myuser --vcenter-password mypassword
 ```
 
 ## Usage
@@ -124,12 +124,15 @@ _The IP address of the machine is not returned yet as this requires a call to a 
 
 Create a new machine by cloning an existing machine or a template. This machine will be bootstrapped by Chef, as long as all the relevant details are in the `knife.rb` file.
 
-Parameters that are required are:
+The following parameters are required:
 
- - `--targethost` - The host that the virtual machine should be created on
- - `--folder` - Folder that machine should be stored in. This must already exist.
  - `--datacenter` - Datacenter in the vSphere environment that controls the target host
  - `--template` - Name of the virtual machine or template to use
+
+There are some optional parameters that can be specified:
+
+ - `--targethost` - The host that the virtual machine should be created on. If not specified the first host in the cluster is used.
+ - `--folder` - Folder that machine should be stored in. If specified this must already exist.
 
 ```
 $ knife vcenter vm clone example-01 --targethost 172.16.20.3 --folder example --ssh-password P@ssw0rd! --datacenter Datacenter --template ubuntu16-template -N example-01

--- a/lib/chef/knife/cloud/vcenter_service.rb
+++ b/lib/chef/knife/cloud/vcenter_service.rb
@@ -101,6 +101,8 @@ class Chef
             # Update these using the REST API so that they can be passed to the support library
             options[:targethost] = get_host(options[:targethost])
 
+            options[:resource_pool] = get_resource_pool(options[:resource_pool])
+
             # Configure the folder option as a has with the name an the id
             options[:folder] = {
               name: options[:folder],
@@ -170,23 +172,46 @@ class Chef
         end
 
         def get_host(name)
-          filter = Com::Vmware::Vcenter::Host::FilterSpec.new({names: Set.new([name])})
           host_obj = Com::Vmware::Vcenter::Host.new(vapi_config)
-          host = host_obj.list(filter)
+
+          if name.nil?
+            host = host_obj.list
+          else
+            filter = Com::Vmware::Vcenter::Host::FilterSpec.new({names: Set.new([name])})
+            host = host_obj.list(filter)
+          end
+
           host[0].host
         end
 
         def get_datastore(name)
-          filter = Com::Vmware::Vcenter::Datastore::FilterSpec.new({names: Set.new([name])})
           datastore_obj = Com::Vmware::Vcenter::Datastore.new(vapi_config)
-          datastore = datastore_obj.list(filter)
+
+          if name.nil?
+            datastore = datastore_obj.list
+          else
+            filter = Com::Vmware::Vcenter::Datastore::FilterSpec.new({names: Set.new([name])})
+            datastore = datastore_obj.list(filter)
+          end
+
           datastore[0].datastore
         end
 
-        def get_resourcepool(name)
-          filter = Com::Vmware::Vcenter::ResourcePool::FilterSpec.new({names: Set.new([name])})
-          resource_pool_obj = Com::Vmware::Vcenter::ResourcePool.new(vapi_config)
-          resource_pool = resource_pool_obj.list(filter)
+        def get_resource_pool(name)
+          # Create a resource pool object
+          rp_obj = Com::Vmware::Vcenter::ResourcePool.new(vapi_config)
+
+          # If a name has been set then try to find it, otherwise use the first
+          # resource pool that can be found
+          if name.nil?
+            resource_pool = rp_obj.list
+          else
+            # create a filter to find the named resource pool
+            filter = Com::Vmware::Vcenter::ResourcePool::FilterSpec.new(names: Set.new([name]))
+            resource_pool = rp_obj.list(filter)
+            raise format('Unable to find Resource Pool: %s', name) if resource_pool.nil?
+          end
+
           resource_pool[0].resource_pool
         end
 

--- a/lib/chef/knife/cloud/vcenter_service.rb
+++ b/lib/chef/knife/cloud/vcenter_service.rb
@@ -97,6 +97,8 @@ class Chef
           case options[:type]
           when "clone"
 
+            datacenter_exists?(options[:datacenter])
+
             # Some of ht eoptions need to be the ID of the component in VMWAre
             # Update these using the REST API so that they can be passed to the support library
             options[:targethost] = get_host(options[:targethost])
@@ -159,6 +161,14 @@ class Chef
 
         def list_clusters
           Com::Vmware::Vcenter::Cluster.new(vapi_config).list()
+        end
+
+        def datacenter_exists?(name)
+          filter = Com::Vmware::Vcenter::Datacenter::FilterSpec.new(names: Set.new([name]))
+          dc_obj = Com::Vmware::Vcenter::Datacenter.new(vapi_config)
+          dc = dc_obj.list(filter)
+  
+          raise format('Unable to find data center: %s', name) if dc.empty?
         end
 
         def get_folder(name)

--- a/lib/chef/knife/cloud/vcenter_service_options.rb
+++ b/lib/chef/knife/cloud/vcenter_service_options.rb
@@ -21,7 +21,7 @@ class Chef
   class Knife
     class Cloud
       # rubocop:disable Style/AlignParameters
-      # runodop:disable Metrics/BlockLength
+      # rubocop:disable Metrics/BlockLength
       module VcenterServiceOptions
         def self.included(includer)
           includer.class_eval do

--- a/lib/chef/knife/vcenter_vm_clone.rb
+++ b/lib/chef/knife/vcenter_vm_clone.rb
@@ -59,6 +59,10 @@ class Chef
                long:        "--pool NAME",
                description: "Name of resource pool to use when creating the machine"
 
+        option :node_ssl_verify_mode,
+               :long        => "--node-ssl-verify-mode [peer|none]",
+               :description => "Whether or not to verify the SSL cert for all HTTPS requests."
+
         def validate_params!
           super
 
@@ -80,9 +84,8 @@ class Chef
             datacenter:   locate_config_value(:datacenter),
             poweron:      !locate_config_value(:disable_power_on),
             folder:       locate_config_value(:folder),
-            resource_pool:locate_config_value(:pool),
+            resource_pool: locate_config_value(:pool),
           }
-
         end
 
         def before_bootstrap

--- a/lib/chef/knife/vcenter_vm_clone.rb
+++ b/lib/chef/knife/vcenter_vm_clone.rb
@@ -55,6 +55,10 @@ class Chef
                long:        "--folder NAME",
                description: "Folder to deploy the new machine into"
 
+        option :pool,
+               long:        "--pool NAME",
+               description: "Name of resource pool to use when creating the machine"
+
         def validate_params!
           super
 
@@ -75,7 +79,8 @@ class Chef
             targethost:   locate_config_value(:targethost),
             datacenter:   locate_config_value(:datacenter),
             poweron:      !locate_config_value(:disable_power_on),
-            folder:       locate_config_value(:folder)
+            folder:       locate_config_value(:folder),
+            resource_pool:locate_config_value(:pool),
           }
 
         end

--- a/lib/chef/knife/vcenter_vm_clone.rb
+++ b/lib/chef/knife/vcenter_vm_clone.rb
@@ -32,7 +32,7 @@ class Chef
         include VcenterServiceOptions
         include ServerCreateOptions
 
-        banner 'knife vcenter vm clone NAME'
+        banner 'knife vcenter vm clone NAME (options)'
 
         option :template,
                long:        "--template NAME",
@@ -62,7 +62,7 @@ class Chef
             ui.error('You must provide the name of the new machine')
           end
 
-          check_for_missing_config_values!(:template, :targethost, :datacenter)
+          check_for_missing_config_values!(:template, :datacenter)
         end
 
         def before_exec_command

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -35,6 +35,8 @@ class Support
       dc = vim.serviceInstance.find_datacenter(options[:datacenter])
       src_vm = dc.find_vm(options[:template])
 
+      raise format("Unable to find template: %s", options[:template]) if src_vm.nil?
+
       # Specify where the machine is going to be created
       relocate_spec = RbVmomi::VIM.VirtualMachineRelocateSpec
       relocate_spec.host = options[:targethost]

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -31,16 +31,16 @@ class Support
     end
 
     def clone
-
       # set the datacenter name
       dc = vim.serviceInstance.find_datacenter(options[:datacenter])
       src_vm = dc.find_vm(options[:template])
-      hosts = dc.hostFolder.children
 
       # Specify where the machine is going to be created
       relocate_spec = RbVmomi::VIM.VirtualMachineRelocateSpec
       relocate_spec.host = options[:targethost]
-      relocate_spec.pool = hosts.first.resourcePool
+
+      # Set the resource pool
+      relocate_spec.pool = options[:resource_pool]
 
       clone_spec = RbVmomi::VIM.VirtualMachineCloneSpec(location: relocate_spec,
                                                         powerOn: options[:poweron],
@@ -49,11 +49,10 @@ class Support
       # Set the folder to use
       dest_folder = options[:folder].nil? ? src_vm.parent : options[:folder][:id]
 
-      puts "Cloning the template to create the new machine..."
+      puts "Cloning the template '#{options[:template]}' to create the VM..."
       task = src_vm.CloneVM_Task(folder: dest_folder, name: options[:name], spec: clone_spec)
       # TODO: it would be nice to have dots to tell you it's working here
       task.wait_for_completion
-
 
       # get the IP address of the machine for bootstrapping
       # machine name is based on the path, e.g. that includes the folder


### PR DESCRIPTION
### Description

Resource pools and target host are now derived if they are not specified as options for the `vcenter vm create` option.

### Issues Resolved

A resource pool and targethost is required whenever a new machine is created. Now they are derived of they are not explicitly specified:

`targethost` - first host in the cluster
`resource_pool` - first resource pool in the cluster

/cc @jjasghar 