### PR TITLE
Unpinning Chef, because it is an dependency.

### DIFF
--- a/knife-vcenter.gemspec
+++ b/knife-vcenter.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'chef',         '~> 12'
   spec.add_dependency 'knife-cloud',  '~> 1.2'
   spec.add_dependency 'rb-readline', '~> 0.5'
   spec.add_dependency 'rbvmomi', '~> 1.11'


### PR DESCRIPTION
- Removed the chef 12 pinning.

Signed-off-by: JJ Asghar <jj@chef.io>