### PR TITLE
rubocop security issue

### DIFF
--- a/knife-vcenter.gemspec
+++ b/knife-vcenter.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'github_changelog_generator'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake',    '~> 10.0'
-  spec.add_development_dependency 'rubocop', '~> 0.35'
+  spec.add_development_dependency 'rubocop', '~> 0.49.0'
   spec.add_development_dependency 'ruby-debug-ide', '~> 0.6.0'
   spec.add_development_dependency 'yard'
 


### PR DESCRIPTION
bumped the version to 0.49.0 per github.

Signed-off-by: JJ Asghar <jj@chef.io>
