### PR TITLE
Allow for knife-cloud 2.x

### DIFF
--- a/knife-vcenter.gemspec
+++ b/knife-vcenter.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3"
 
-  spec.add_dependency "knife-cloud", "~> 1.2"
+  spec.add_dependency "knife-cloud", ">= 1.2", "< 3.0"
   spec.add_dependency "rb-readline", "~> 0.5"
   spec.add_dependency "rbvmomi", "~> 1.11"
   spec.add_dependency "savon", "~> 2.11"


### PR DESCRIPTION
2.x is a dependency of some of the other knife plugins and it's holding
back knife-google in chef-workstation

Signed-off-by: Tim Smith <tsmith@chef.io>