### PR TITLE
Don't ship the specs dir in the gem artifact

### DIFF
--- a/knife-vcenter.gemspec
+++ b/knife-vcenter.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
 
   spec.files         = Dir["LICENSE", "lib/**/*"]
-  spec.test_files    = Dir["spec/**/*"]
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.3"


### PR DESCRIPTION
This avoids shippinng these files in each Chef Workstation install

Signed-off-by: Tim Smith <tsmith@chef.io>