### PR TITLE
Allow rbvmomi 2.x

### DIFF
--- a/knife-vcenter.gemspec
+++ b/knife-vcenter.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "knife-cloud", ">= 1.2", "< 3.0"
   spec.add_dependency "rb-readline", "~> 0.5"
-  spec.add_dependency "rbvmomi", "~> 1.11"
+  spec.add_dependency "rbvmomi", ">= 1.11", "< 3.0"
   spec.add_dependency "savon", "~> 2.11"
-  spec.add_dependency "vsphere-automation-sdk", "~> 0.1"
+  spec.add_dependency "vsphere-automation-sdk", "~> 0.4"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
This fixes a bunch of issues and is a major bump because it moves off
the deprecated trollop gem and uses optimist instead

Signed-off-by: Tim Smith <tsmith@chef.io>