### PR TITLE
CHEF-1919 Fixed the knife-vcenter verify test failure

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -10,20 +10,13 @@ expeditor:
       timeout_in_minutes: 30
 
 steps:
-- label: run-lint-and-specs-ruby-2.6
+- label: run-lint-and-specs-ruby-3.1
   command:
     - .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
-        image: ruby:2.6-buster
-- label: run-lint-and-specs-ruby-2.7
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.7-buster
+        image: ruby:3.1-buster
 - label: run-specs-windows
   command:
     - bundle config set --local without docs debug

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -26,3 +26,4 @@ steps:
     executor:
       docker:
         host_os: windows
+        image: rubydistros/windows-2019:3.1

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
     gem "chef-zero", "~> 15"
     gem "chef", "~> 15"
   end
-  gem "knife"
+  gem "knife", ">= 18.0"
 end
 
 group :debug do

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :test do
     gem "chef-zero", "~> 15"
     gem "chef", "~> 15"
   end
+  gem "knife"
 end
 
 group :debug do

--- a/knife-vcenter.gemspec
+++ b/knife-vcenter.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["LICENSE", "lib/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 3.1"
 
-  spec.add_dependency "chef", ">= 15.11"
+  spec.add_dependency "chef", ">= 18.2"
   spec.add_dependency "knife-cloud", ">= 4.0"
   spec.add_dependency "rb-readline", "~> 0.5"
   spec.add_dependency "rbvmomi", ">= 1.11", "< 4.0"

--- a/knife-vcenter.gemspec
+++ b/knife-vcenter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.1"
 
-  spec.add_dependency "chef", ">= 18.2"
+  spec.add_dependency "chef", ">= 18.0"
   spec.add_dependency "knife-cloud", ">= 4.0"
   spec.add_dependency "rb-readline", "~> 0.5"
   spec.add_dependency "rbvmomi", ">= 1.11", "< 4.0"


### PR DESCRIPTION

## Description
updated ruby version to 3.1 and removed 2.7 and 3.0 ruby verify pipeline as the latest chef 18.2.7 supports ruby >= 3.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
